### PR TITLE
bootstrap4 compatible

### DIFF
--- a/Asset.php
+++ b/Asset.php
@@ -41,6 +41,6 @@ class Asset extends AssetBundle
      */
     public $depends = [
         'yii\web\YiiAsset',
-        'yii\bootstrap4\BootstrapAsset',
+        //'yii\bootstrap4\BootstrapAsset',
     ];
 }

--- a/Asset.php
+++ b/Asset.php
@@ -41,6 +41,6 @@ class Asset extends AssetBundle
      */
     public $depends = [
         'yii\web\YiiAsset',
-        'yii\bootstrap\BootstrapAsset',
+        'yii\bootstrap4\BootstrapAsset',
     ];
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "yiisoft/yii2": "*",
-        "bower-asset/bootstrap-select": "1.7.5"
+        "bower-asset/bootstrap-select": "^1.13"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Removed bootstrap from assets and change bootstrap-select min version to 1.13
From 1.13+ version bootstrap-select automatically detects the version of Bootstrap being used. 
So bootstrap just should be registered in globals of project. This way you dont have to install different version depending on bs version. 